### PR TITLE
recommendations v1

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -137,3 +137,11 @@ CREATE TABLE Recommendations (
     recommendationScore DECIMAL(3, 2) NOT NULL
 )
 ENGINE = InnoDB;
+
+CREATE TABLE BuyerPreferences (
+    buyerID INT NOT NULL,
+    categoryID INT NOT NULL,
+    FOREIGN KEY (buyerID) REFERENCES Buyers(buyerID),
+    FOREIGN KEY (categoryID) REFERENCES Categories(categoryID)
+)
+ENGINE = InnoDB;

--- a/login_result.php
+++ b/login_result.php
@@ -25,11 +25,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $_SESSION['logged_in'] = true;
         $usernameQuery = "SELECT username FROM users WHERE email = '$email'";
         $usernameResult = mysqli_query($connection, $usernameQuery);
-        $usernameResultRow = mysqli_fetch_array($usernameResult);  
+        $usernameResultRow = mysqli_fetch_array($usernameResult); 
+        $userIDQuery = "SELECT userID FROM users WHERE email = '$email'";
+        $userIDResult = mysqli_query($connection, $userIDQuery);
+        $userIDResultRow = mysqli_fetch_array($userIDResult); 
         $accountTypeQuery = "SELECT userRole FROM users WHERE email = '$email'";
         $accountTypeResult = mysqli_query($connection, $accountTypeQuery);
         $accountTypeResultRow = mysqli_fetch_array($accountTypeResult);      
-        $_SESSION['username'] = $usernameResultRow['username'];     
+        $_SESSION['username'] = $usernameResultRow['username'];  
+        $_SESSION['userID'] = $userIDResultRow['userID'];   
         $_SESSION['account_type'] = $accountTypeResultRow['userRole'];   
         echo('<div class="text-center">You are now logged in! You will be redirected shortly!</div>');
         // Redirect to index after 2 seconds

--- a/queries/recommendations.sql
+++ b/queries/recommendations.sql
@@ -1,0 +1,91 @@
+-- Version 1 (if sufficient bid history): 
+WITH rankQuery AS (
+    -- Rank query: Count of overlapping auctions based on similar buyers' bidding histories
+    SELECT buyerID, COUNT(DISTINCT auctionID) AS buyerRank
+    FROM bids
+    WHERE auctionID IN (SELECT DISTINCT auctionID FROM bids WHERE buyerID = 1)
+    AND buyerID != 1
+    GROUP BY buyerID
+),
+auctionsQuery AS (
+    -- All auctions bid on by similar buyers but not bid on by the given user (buyerID = 1)
+    SELECT DISTINCT auctionID
+    FROM bids 
+    WHERE buyerID IN (SELECT DISTINCT buyerID FROM bids WHERE auctionID IN (SELECT DISTINCT auctionID FROM bids WHERE buyerID = 1) AND buyerID != 1)
+    -- Exclude auctions given buyer has already bid on or won (by extension)
+    AND auctionID NOT IN (SELECT DISTINCT auctionID FROM bids WHERE buyerID = 1)
+    -- Exclude auctions on given buyer's watchlist
+    AND auctionID NOT IN (SELECT auctionID FROM watchlists WHERE buyerID = 1)
+),
+categoriesQuery AS (
+    -- All categories associated with given buyer's bid history
+    SELECT DISTINCT categoryID
+    FROM auctions
+    WHERE auctionID IN (SELECT DISTINCT auctionID FROM bids WHERE buyerID = 1)
+)
+-- Join the two subqueries to sum the rank values for the auctions (without grouping, multiple rows for each auction by buyer/rank)
+SELECT a.auctionID, SUM(r.buyerRank) AS totalRank
+FROM auctionsQuery a
+-- Left joins since we don't want to exclude auctions outside of given buyer's category history
+LEFT JOIN auctions auc ON a.auctionID = auc.auctionID
+LEFT JOIN categoriesQuery c ON auc.categoryID = c.categoryID
+-- Join table to access relevant buyerIDs 
+INNER JOIN bids b ON a.auctionID = b.auctionID 
+INNER JOIN rankQuery r ON b.buyerID = r.buyerID
+-- Filter for live auctions
+WHERE auc.endTime > NOW()
+GROUP BY a.auctionID
+-- Score weighted up by 25% if auction intersects with given buyer's category history
+ORDER BY CASE WHEN c.categoryID IS NOT NULL THEN (totalRank * 1.25) ELSE totalRank END DESC
+LIMIT 5;
+
+-- Version 2 (if no bid history but some buyerPreferences)
+SELECT a.auctionID
+FROM auctions a
+WHERE a.categoryID IN (SELECT categoryID FROM buyerPreferences WHERE buyerID = 1)
+AND a.endTime > NOW()
+ORDER BY (SELECT COUNT(*) FROM bids b WHERE a.auctionID = b.auctionID) DESC
+LIMIT 5;
+
+-- Version 3 (if no bid history and no buyerPreferences)
+SELECT a.auctionID
+FROM auctions a
+WHERE a.endTime > NOW()
+ORDER BY (SELECT COUNT(*) FROM bids b WHERE a.auctionID = b.auctionID) DESC
+LIMIT 5;
+
+/* 
+Micro Workflow (done):
+i. Has user made any bids?
+    1. Yes: Proceed with main query 
+        i. Does main query yield N results?
+            1. Yes: Done
+            2. No: Does user have buyerPreferences?
+                i. Yes: Proceed with fallback (with buyerPreferences)
+                    1. Do both queries yield N results?
+                        i. Yes: Done
+                        ii. No: Proceed with fallback (without buyerPreferences) and provide recommendations whether or not they total to N
+                ii. No: Proceed to fallback (without buyerPreferences) and provide recommendations whether or not they total to N
+    2. No: Does user have buyerPreferences?
+        i. Yes: Proceed with fallback (with buyerPreferences)
+            1. Does query yield N results?
+                i. Yes: Done
+                ii. No: Proceed with fallback (without buyerPreferences) and provide recommendations whether or not they total to N
+        ii. No: Proceed to fallback (without buyerPreferences) and provide recommendations whether or not they total to N
+
+Macro Workflow (outstanding): 
+* Pre-calculate recommendations for each user at a regular interval (eg. overnight); keep a larger amount (eg. 25)
+* Each time a user accesses recommendations, filter the larger pre-calculated set by live auctions and limit to a lower amount (eg. 10)
+* If recommendations are less than 10, exceptionally run the micro workflow there and then for the remainder 
+* If auction expires, delete it from pre-calculated set of recommendations (that logic applies to auction expiry event, not this)
+
+Plan ahead (Raj):
+i. buyerPreferences / update buyer registration [Patch 1]
+ii. recommendations [Patch 1]
+iii. userViews [Patch 2]
+v. seller recommendations: general insights for "My Listings" (views, bids) [Patch 2]
+vi. search: sort by views, filter by buyer preferences [Patch 2]
+iv. questions [Patch 3]
+vi. Remainder (delegated): updates/notifications, watchlist
+
+

--- a/recommendation_utilities.php
+++ b/recommendation_utilities.php
@@ -1,0 +1,84 @@
+<?php 
+    $recommendations = [];
+    $totalRecommendations = 25;
+    $remainingRecommendations = 25;
+
+    function getBidCount($connection, $userID) {
+        $checkBidsQuery = "SELECT COUNT(buyerID) AS count FROM bids WHERE buyerID = $userID";
+        $checkBidsResult = mysqli_query($connection, $checkBidsQuery);
+        $checkBidsResultRow = mysqli_fetch_array($checkBidsResult);
+        return $checkBidsResultRow['count'];
+    }
+    
+    function checkBuyerPreferences($connection, $userID) {
+        $checkBuyerPreferencesQuery = "SELECT COUNT(categoryID) AS count FROM buyerPreferences WHERE buyerID = $userID";
+        $checkBuyerPreferencesResult = mysqli_query($connection, $checkBuyerPreferencesQuery);
+        $checkBuyerPreferencesResultRow = mysqli_fetch_array($checkBuyerPreferencesResult);
+        return $checkBuyerPreferencesResultRow['count'];
+    }
+    
+    $mainQuery = 
+    "WITH rankQuery AS (
+        SELECT buyerID, COUNT(DISTINCT auctionID) AS buyerRank
+        FROM bids
+        WHERE auctionID IN (SELECT DISTINCT auctionID FROM bids WHERE buyerID = 1)
+        AND buyerID != 1
+        GROUP BY buyerID
+    ),
+    auctionsQuery AS (        
+        SELECT DISTINCT auctionID
+        FROM bids 
+        WHERE buyerID IN (SELECT DISTINCT buyerID FROM bids WHERE auctionID IN (SELECT DISTINCT auctionID FROM bids WHERE buyerID = 1) AND buyerID != 1)        
+        AND auctionID NOT IN (SELECT DISTINCT auctionID FROM bids WHERE buyerID = 1)        
+        AND auctionID NOT IN (SELECT auctionID FROM watchlists WHERE buyerID = 1)
+    ),
+    categoriesQuery AS (        
+        SELECT DISTINCT categoryID
+        FROM auctions
+        WHERE auctionID IN (SELECT DISTINCT auctionID FROM bids WHERE buyerID = 1)
+    )    
+    SELECT a.auctionID, SUM(r.buyerRank) AS totalRank
+    FROM auctionsQuery a    
+    LEFT JOIN auctions auc ON a.auctionID = auc.auctionID
+    LEFT JOIN categoriesQuery c ON auc.categoryID = c.categoryID    
+    INNER JOIN bids b ON a.auctionID = b.auctionID 
+    INNER JOIN rankQuery r ON b.buyerID = r.buyerID    
+    WHERE auc.endTime > NOW()
+    GROUP BY a.auctionID    
+    ORDER BY CASE WHEN c.categoryID IS NOT NULL THEN (totalRank * 1.25) ELSE totalRank END DESC
+    LIMIT $remainingRecommendations;";
+
+    $fallbackOneQuery = "SELECT a.auctionID
+        FROM auctions a
+        WHERE a.categoryID IN (SELECT categoryID FROM buyerPreferences WHERE buyerID = 1)
+        AND a.endTime > NOW()
+        ORDER BY (SELECT COUNT(*) FROM bids b WHERE a.auctionID = b.auctionID) DESC
+        LIMIT $remainingRecommendations;";
+
+    $fallbackTwoQuery = "SELECT a.auctionID
+        FROM auctions a
+        WHERE a.endTime > NOW()
+        ORDER BY (SELECT COUNT(*) FROM bids b WHERE a.auctionID = b.auctionID) DESC
+        LIMIT $remainingRecommendations";
+    
+    function runMainQuery($connection, $mainQuery, &$recommendations) {
+        $mainResult = mysqli_query($connection, $mainQuery);
+        while ($row = mysqli_fetch_assoc($mainResult)) {
+            $recommendations[] = $row['auctionID'];
+        }
+    }
+
+    function runFallbackQueryOne($connection, $fallbackOneQuery, &$recommendations) {
+        $fallbackOneResult = mysqli_query($connection, $fallbackOneQuery);
+        while ($row = mysqli_fetch_assoc($fallbackOneResult)) {
+            $recommendations[] = $row['auctionID'];
+        }
+    }
+
+    function runFallbackQueryTwo($connection, $fallbackTwoQuery, &$recommendations) {
+        $fallbackTwoResult = mysqli_query($connection, $fallbackTwoQuery); 
+        while ($row = mysqli_fetch_assoc($fallbackTwoResult)) {
+          $recommendations[] = $row['auctionID'];
+        }
+    }            
+?>

--- a/recommendations.php
+++ b/recommendations.php
@@ -1,5 +1,6 @@
 <?php include_once("header.php")?>
 <?php require("utilities.php")?>
+<?php require("recommendation_utilities.php")?>
 
 <div class="container">
 
@@ -13,10 +14,55 @@
   // the shared "utilities.php" where they can be shared by multiple files.
   
   
-  // TODO: Check user's credentials (cookie/session).
-  
-  // TODO: Perform a query to pull up auctions they might be interested in.
-  
+  // TODO: Check user's credentials (cookie/session). 
+  require 'database.php';  
+
+  if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] === true) {
+    $loggedIn = true;
+    $username = $_SESSION['username'];
+    $userID = $_SESSION['userID'];
+    $accountType = $_SESSION['account_type'];
+  } else {
+    $loggedIn = false;
+    $accountType = 'seller';
+  }    
+  // TODO: Perform a query to pull up auctions they might be interested in.       
+  $checkBidsFinalResult = getBidCount($connection, $userID);
+  $checkBuyerPreferencesFinalResult = checkBuyerPreferences($connection, $userID);
+    
+  if ($checkBidsFinalResult > 1) {    
+    runMainQuery($connection, $mainQuery, $recommendations);           
+    if (count($recommendations) < $totalRecommendations) {
+      $remainingRecommendations = $totalRecommendations - count($recommendations);      
+      if ($checkBuyerPreferencesFinalResult > 1) {               
+        runFallbackQueryOne($connection, $fallbackOneQuery, $recommendations);        
+        if (count($recommendations) < $totalRecommendations) {
+          $remainingRecommendations = $totalRecommendations - count($recommendations);          
+          runFallbackQueryTwo($connection, $fallbackTwoQuery, $recommendations);          
+        }
+      } else {        
+        runFallbackQueryTwo($connection, $fallbackTwoQuery, $recommendations);        
+      }
+    }
+  } else {    
+    if ($checkBuyerPreferencesFinalResult > 1) {      
+      runFallbackQueryOne($connection, $fallbackOneQuery, $recommendations);      
+      if (count($recommendations) < $totalRecommendations) {
+        $remainingRecommendations = $totalRecommendations - count($recommendations);        
+        runFallbackQueryTwo($connection, $fallbackTwoQuery, $recommendations);        
+      }
+    } else {      
+      runFallbackQueryTwo($connection, $fallbackTwoQuery, $recommendations);      
+    }
+  }
+      
+  echo '<pre>';
+    var_dump($recommendations);
+  echo '</pre>';
+
+
+
   // TODO: Loop through results and print them out as list items.
   
 ?>
+


### PR DESCRIPTION
** Please review/approve "Auction Creation" before this! **

Recommendation Logic:
There are three queries that support this: one uses collaborative filtering, and there are two fallbacks. The collaborative filtering works as follows: given a buyer (hereafter referred to as X) who has made at least one bid, we identify all other buyers (hereafter referred to as Y) who have also bid on the auctions that X has. We then rank members of Y by the amount of overlap in auctions bid on between themselves and X; the rank is literally the count of distinct auctions that that member of Y has bid on that X has also bid on herself. We then consider all the live auctions Y has bid on that X has not (hereafter referred to as Z). For each auction in Z, we consider all members of Y that have bid on it and sum their respective ranks into an aggregate figure; in this way we can find an overall rank for each auction. 

The first fallback query considers the case when a buyer hasn't yet made any bids. If this is the case, we consider the buyer's "buyerPreferences" upon registration (a new entity; this is implemented in the schema, hence the merge conflict). This can be none, some or all of the categories. If buyer preferences exist, we consider all live auctions within these respective categories and rank them by bid counts. 

The second fallback query considers the case when a buyer didn't specify any buyerPreferences upon registration. Here we would simply consider all live auctions across any category and rank them by bid counts. 

Total recommendations are currently set to a given number (right now, 25). Generation works such even if the collaborative filtering doesn't reach this number, the fallbacks will provide the remainder (the first fallback will be prioritised over the second assuming the buyer did specify buyerPreferences). The only case when total recommendations wouldn't equal this given number is if the amount of live auctions is less than it. 

Points:

i. Right now, the recommendations page would only show an array of auctionIDs. Once search is implemented, utilities.php could tie into the visuals here. 

ii. There will be a merge conflict with "Auction Creation" since we're both changing schema.sql; however the differences are compatible. I've added the entity "buyerPreferences" for the first fallback query.

iii. Dummy data is useful for validation purposes (for this feature and everything else).

iv. Right now recommendations will be generated for each user each time they go onto recommendations.php; an array of auctionIDs is returned and the recommendations entity isn't being used. This entity would be useful if we decide to pre-calculate and persist recommendations via an overnight job. If some auctions within these recommendations expire, we'd need separate logic for auction expiries to delete correspondent rows in the recommendations entity. 

v. I need to update buyer registration to allow for buyerPreferences.