### PR TITLE
Bid suggestions + Auction Analytics 

### DIFF
--- a/auction_analytics.php
+++ b/auction_analytics.php
@@ -40,7 +40,11 @@ if ($liveAuctionsResult && mysqli_num_rows($liveAuctionsResult) > 0) {
 
         $viewAmount = giveAuctionViews($auctionID,$connection);
         $bidAmount = giveAuctionBids($auctionID,$connection);
-        $viewBidRatio = round($viewAmount / $bidAmount ,1);
+        if ($bidAmount > 0) {
+    $viewBidRatio = round($viewAmount / $bidAmount, 1);
+} else {
+    $viewBidRatio = 0;
+}
 
         echo("<li class='list-group-item'>
                 <strong><a href='listing.php?item_id=$auctionID'>$auctionTitle</a></strong>

--- a/auction_analytics.php
+++ b/auction_analytics.php
@@ -37,10 +37,18 @@ if ($liveAuctionsResult && mysqli_num_rows($liveAuctionsResult) > 0) {
         $endTime = $row['endTime'];
         $currentPrice = $row['currentPrice'];
         $currentAuctionSum = $currentAuctionSum + $currentPrice;
+
+        $viewAmount = giveAuctionViews($auctionID,$connection);
+        $bidAmount = giveAuctionBids($auctionID,$connection);
+        $viewBidRatio = round($viewAmount / $bidAmount ,1);
+
         echo("<li class='list-group-item'>
                 <strong><a href='listing.php?item_id=$auctionID'>$auctionTitle</a></strong>
                 <br>Current Price: <strong>£$currentPrice</strong>
-                <br>Ends On: <strong>$endTime</strong><br>
+                <br>Ends On: <strong>$endTime</strong>
+                <br>Views: <strong>$viewAmount</strong>
+                <br>Bids: <strong>$bidAmount</strong>
+                <br>View to Bid Ratio of <strong>$viewBidRatio</strong>
               </li>");
         
     }
@@ -51,6 +59,7 @@ if ($liveAuctionsResult && mysqli_num_rows($liveAuctionsResult) > 0) {
 }
 
 // Following chunk shows all the expired auctions a User has 
+// this includes extras such as increase over reserve price
 $expiredAuctionsQuery = "SELECT auctionID
                         FROM Auctions
                         WHERE sellerID = $sellerID
@@ -64,7 +73,6 @@ if ($expiredAuctionsResult && mysqli_num_rows($expiredAuctionsResult) > 0) {
 
         $auctionID = $row['auctionID'];
         $aucDetails = giveAuctionDetails($auctionID,$connection);
-
         $auctionTitle = $aucDetails['auctionTitle'];
         $currentPrice = $aucDetails['currentPrice'];
         $startingPrice = $aucDetails['startingPrice'];
@@ -76,7 +84,7 @@ if ($expiredAuctionsResult && mysqli_num_rows($expiredAuctionsResult) > 0) {
                 <strong><a href='listing.php?item_id=$auctionID'>$auctionTitle</a></strong>
                 <br>Starting Price: <strong>£$startingPrice</strong>
                 <br>Final Price: <strong>£$currentPrice</strong>
-                <br>Additional gain over Reserve Price: <strong>£$priceIncrease</strong>
+                <br>Increase over Reserve Price: <strong>£$priceIncrease</strong>
                 <br>Ended On: <strong>$endTime</strong><br>
               </li>");
     }
@@ -142,17 +150,19 @@ if ($leastPopularAuctionResult && mysqli_num_rows($leastPopularAuctionResult) > 
               </li>");
 }
 
+// 
+
+
+
+
 // Potential Analytics/Features of the page 
-
-// Views to bid ratio of each running auction?? 
-// Final sale price vs starting price of expired auctions 
-
 
 // Make a seller (lifetime) analytics table 
 // this is updated every time a seller clicks on the refresh button
+
 // based only off completed auctions 
 // sellerAnalytics (sellerID, totalRevenue, avgViews , successRate, lastUpdated)
-
+// implement this to gamify the experience (give the seller a rank of their avgViews,successRate and totalRevenue)
 
 
 ?>

--- a/auction_analytics.php
+++ b/auction_analytics.php
@@ -150,19 +150,6 @@ if ($leastPopularAuctionResult && mysqli_num_rows($leastPopularAuctionResult) > 
               </li>");
 }
 
-// 
-
-
-
-
-// Potential Analytics/Features of the page 
-
-// Make a seller (lifetime) analytics table 
-// this is updated every time a seller clicks on the refresh button
-
-// based only off completed auctions 
-// sellerAnalytics (sellerID, totalRevenue, avgViews , successRate, lastUpdated)
-// implement this to gamify the experience (give the seller a rank of their avgViews,successRate and totalRevenue)
 
 
 ?>

--- a/auction_analytics.php
+++ b/auction_analytics.php
@@ -204,8 +204,6 @@ if (!isset($numberOfFinishedAuctions)) {
     echo("Average views for Completed Listings : <strong>$avgViews</strong><br>");
 }
 
-
-
 ?>
 
 

--- a/auction_analytics.php
+++ b/auction_analytics.php
@@ -151,6 +151,60 @@ if ($leastPopularAuctionResult && mysqli_num_rows($leastPopularAuctionResult) > 
 }
 
 
+echo('<br><h4>Lifetime Analytics</h4>');
+// Following chunk will display the lifetime analytics of the user 
+
+// Find the number of distinct auctions the user has put up
+
+$numberOfFinishedAuctionsQuery = "SELECT COUNT(*) AS total
+                    FROM Auctions
+                    WHERE sellerID = $sellerID
+                    AND endTime <= NOW();";
+$numberOfFinishedAuctionsResult = mysqli_query($connection, $numberOfFinishedAuctionsQuery);
+$numberOfFinishedAuctionsRow = mysqli_fetch_assoc($numberOfFinishedAuctionsResult);
+
+if (isset($numberOfFinishedAuctionsRow)) {
+    $numberOfFinishedAuctions = $numberOfFinishedAuctionsRow['total'];
+}
+else {
+    $numberOfFinishedAuctions = NULL;
+}
+
+
+
+if (!isset($numberOfFinishedAuctions)) {
+    echo('An error occured whilst retrieving lifetime analytics');
+} else if ($numberOfFinishedAuctions == 0) {
+    echo('No auctions have placed and/or have finished.');
+} else {
+    echo("Total number of finished auctions: <strong>$numberOfFinishedAuctions</strong>. <br>");
+    
+    // find total revenue from all auctions 
+    $totalRevenueQuery = "SELECT SUM(currentPrice) AS totalRevenue
+                        FROM Auctions
+                        WHERE sellerID = $sellerID
+                        AND endTime <= NOW();";
+    $totalRevenueResult = mysqli_query($connection, $totalRevenueQuery);
+    $totalRevenueRow = mysqli_fetch_assoc($totalRevenueResult);
+    $totalRevenue = round($totalRevenueRow['totalRevenue']);
+    echo("Total Revenue from all Finished Listings: <strong>£$totalRevenue</strong><br>");
+
+    // find total views from all finished auctions 
+    $totalViewsQuery = " SELECT COUNT(UV.userID) AS totalViews
+                        FROM Auctions A
+                        JOIN UserViews UV ON A.auctionID = UV.auctionID
+                        WHERE A.sellerID = $sellerID
+                        AND A.endTime <= NOW();";
+    
+    $totalViewsResult = mysqli_query($connection, $totalViewsQuery);
+    $totalViewsRow = mysqli_fetch_assoc($totalViewsResult);
+    $totalViews = round($totalViewsRow['totalRevenue']);
+    $avgViews = $totalViews / $numberOfFinishedAuctions;
+
+    echo("Average views for Completed Listings : <strong>$avgViews</strong><br>");
+}
+
+
 
 ?>
 

--- a/auction_analytics.php
+++ b/auction_analytics.php
@@ -1,0 +1,163 @@
+<?php include_once("header.php"); ?>
+<?php require_once("utilities.php"); ?>
+<?php require_once("database.php"); ?>
+
+<div class="container">
+
+<h2 class="my-3">Auction Analytics </h2>
+
+<?php 
+
+// If user is not logged in or not a seller, they should not be able to use this page.
+if (!isset($_SESSION['account_type']) || ($_SESSION['account_type'] == 'buyer')) {
+    header('Location: browse.php');
+}
+
+$sellerID = $_SESSION['userID'];
+
+
+echo('<h4>Live Auctions</h4>');
+
+$currentAuctionSum = 0;
+
+// Following chunk displays all live auctions the seller has 
+$liveAuctionsQuery = "SELECT auctionID, auctionTitle, startingPrice, endTime, currentPrice
+                        FROM Auctions
+                        WHERE sellerID = $sellerID
+                        AND startTime <= NOW()
+                        AND endTime > NOW()";
+$liveAuctionsResult = mysqli_query($connection,$liveAuctionsQuery);
+if ($liveAuctionsResult && mysqli_num_rows($liveAuctionsResult) > 0) {
+    echo('<ul class="list-group">');
+    // iterate through all auctions fetched by sql query
+    while ($row = mysqli_fetch_assoc($liveAuctionsResult)) {
+        $auctionID = $row['auctionID'];
+        $auctionTitle = $row['auctionTitle'];
+        $startingPrice = $row['startingPrice'];
+        $endTime = $row['endTime'];
+        $currentPrice = $row['currentPrice'];
+        $currentAuctionSum = $currentAuctionSum + $currentPrice;
+        echo("<li class='list-group-item'>
+                <strong><a href='listing.php?item_id=$auctionID'>$auctionTitle</a></strong>
+                <br>Current Price: <strong>£$currentPrice</strong>
+                <br>Ends On: <strong>$endTime</strong><br>
+              </li>");
+        
+    }
+    echo('Total Price of all running auctions:'.'<strong>'.'£'.$currentAuctionSum.'</strong>');
+    echo '</ul><br><br>';
+} else {
+    echo('<div class="alert alert-info">You have no live auctions.</div>');
+}
+
+// Following chunk shows all the expired auctions a User has 
+$expiredAuctionsQuery = "SELECT auctionID
+                        FROM Auctions
+                        WHERE sellerID = $sellerID
+                        AND endTime <= NOW()";
+$expiredAuctionsResult = mysqli_query($connection,$expiredAuctionsQuery);
+echo '<h4>Expired Auctions</h4>';
+if ($expiredAuctionsResult && mysqli_num_rows($expiredAuctionsResult) > 0) {
+    echo('<ul class="list-group">');
+    // iterate through all auctions fetched by sql query
+    while ($row = mysqli_fetch_assoc($expiredAuctionsResult)) {
+
+        $auctionID = $row['auctionID'];
+        $aucDetails = giveAuctionDetails($auctionID,$connection);
+
+        $auctionTitle = $aucDetails['auctionTitle'];
+        $currentPrice = $aucDetails['currentPrice'];
+        $startingPrice = $aucDetails['startingPrice'];
+        $reservePrice = $aucDetails['reservePrice'];
+        $priceIncrease = $currentPrice - $reservePrice;
+        $endTime = $aucDetails['endTime'];
+
+        echo("<li class='list-group-item'>
+                <strong><a href='listing.php?item_id=$auctionID'>$auctionTitle</a></strong>
+                <br>Starting Price: <strong>£$startingPrice</strong>
+                <br>Final Price: <strong>£$currentPrice</strong>
+                <br>Additional gain over Reserve Price: <strong>£$priceIncrease</strong>
+                <br>Ended On: <strong>$endTime</strong><br>
+              </li>");
+    }
+    echo '</ul><br>';
+} else {
+    echo('<div class="alert alert-info">You have no expired auctions.</div>');
+}
+
+// Following chunk will display the most/least popular live auctions
+$mostPopularAuctionQuery = "SELECT UV.auctionID, COUNT(DISTINCT UV.userID) as distinctViews
+                            FROM UserViews UV 
+                            JOIN Auctions A ON UV.auctionID = A.auctionID
+                            GROUP BY UV.auctionID 
+                            ORDER BY distinctViews DESC
+                            LIMIT 1;";
+
+$leastPopularAuctionQuery = "SELECT UV.auctionID, COUNT(DISTINCT UV.userID) AS distinctViews
+                            FROM UserViews UV
+                            JOIN Auctions A ON UV.auctionID = A.auctionID
+                            GROUP BY UV.auctionID
+                            ORDER BY distinctViews ASC
+                            LIMIT 1;";
+
+$mostPopularAuctionResult = mysqli_query($connection,$mostPopularAuctionQuery);
+$leastPopularAuctionResult = mysqli_query($connection,$leastPopularAuctionQuery);
+
+// get auction details of the most/least popular auctions so that they can be displayed 
+$mostPopularAuction = mysqli_fetch_assoc($mostPopularAuctionResult);
+$leastPopularAuction = mysqli_fetch_assoc($leastPopularAuctionResult);
+
+$mostPopularAuctionID = $mostPopularAuction['auctionID'];
+$leastPopularAuctionID = $leastPopularAuction['auctionID'];
+
+if ($mostPopularAuctionResult && mysqli_num_rows($mostPopularAuctionResult) > 0) {
+    $aucDetails = giveAuctionDetails($mostPopularAuctionID,$connection);
+    $auctionTitle = $aucDetails['auctionTitle'];
+    $currentPrice = $aucDetails['currentPrice'];
+    $endTime = $aucDetails['endTime'];
+    $disViews = $mostPopularAuction['distinctViews'];
+
+    echo('<br><h4>Most Viewed Auction</h4>');
+    echo("<li class='list-group-item'>
+                <strong><a href='listing.php?item_id=$mostPopularAuctionID'>$auctionTitle</a></strong>
+                <br>Current Price: <strong>£$currentPrice</strong>
+                <br>Ends On: <strong>$endTime</strong>
+                <br>Distinct Views: <strong>$disViews</strong>
+              </li>");
+}
+
+if ($leastPopularAuctionResult && mysqli_num_rows($leastPopularAuctionResult) > 0) {
+    $aucDetails = giveAuctionDetails($leastPopularAuctionID,$connection);
+    $auctionTitle = $aucDetails['auctionTitle'];
+    $currentPrice = $aucDetails['currentPrice'];
+    $endTime = $aucDetails['endTime'];
+    $disViews = $leastPopularAuction['distinctViews'];
+
+    echo('<br><h4>Least Viewed Auction</h4>');
+    echo("<li class='list-group-item'>
+                <strong><a href='listing.php?item_id=$mostPopularAuctionID'>$auctionTitle</a></strong>
+                <br>Current Price: <strong>£$currentPrice</strong>
+                <br>Ends On: <strong>$endTime</strong>
+                <br>Distinct Views: <strong>$disViews</strong>
+              </li>");
+}
+
+// Potential Analytics/Features of the page 
+
+// Views to bid ratio of each running auction?? 
+// Final sale price vs starting price of expired auctions 
+
+
+// Make a seller (lifetime) analytics table 
+// this is updated every time a seller clicks on the refresh button
+// based only off completed auctions 
+// sellerAnalytics (sellerID, totalRevenue, avgViews , successRate, lastUpdated)
+
+
+
+?>
+
+
+</div>
+
+<?php include_once "footer.php" ?>

--- a/bid_listing.php
+++ b/bid_listing.php
@@ -66,7 +66,7 @@ if ($auctionQuery && $auction = mysqli_fetch_assoc($auctionQuery)) {
     
     if (isset($imageID)) {
       $imageDataQuery = "SELECT imageFile FROM Images WHERE imageID='$imageID'";
-      $imageDataResult = mysqli_query($connection, $imageDataQuery) or die("Error making select userData query".mysql_error());
+      $imageDataResult = mysqli_query($connection, $imageDataQuery) or die("Error making select userData query".mysqli_error($connection));
 
       if ($imageDataResult && $imageDataRow = mysqli_fetch_assoc($imageDataResult)) {
         $imageData = base64_encode($imageDataRow['imageFile']);
@@ -152,7 +152,7 @@ if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] === true) {
         The auction was cancelled.
     <?php endif; ?>
 <?php else: ?>
-     Auction ends <?php echo(date_format($end_time, 'j M H:i') . $time_remaining) ?></p>  
+    Auction ends <?php echo(date_format($end_time, 'j M H:i') . $time_remaining) ?></p>  
     <p class="lead">Current bid: £<?php echo(number_format($current_price, 2)) ?></p>
     <h4>Bid History</h4>
     <?php

--- a/header.php
+++ b/header.php
@@ -79,6 +79,9 @@
 	<li class="nav-item mx-1">
       <a class="nav-link" href="mylistings.php">My Listings</a>
     </li>
+  <li class="nav-item mx-1">
+      <a class="nav-link" href="auction_analytics.php">Auction Analytics</a>
+    </li>
 	<li class="nav-item ml-3">
       <a class="nav-link btn border-light" href="create_auction.php">+ Create auction</a>
     </li>');
@@ -97,6 +100,9 @@
     <li class="nav-item mx-1">
         <a class="nav-link" href="mylistings.php">My Listings</a>
       </li>
+    <li class="nav-item mx-1">
+      <a class="nav-link" href="auction_analytics.php">Auction Analytics</a>
+    </li>
     <li class="nav-item ml-3">
         <a class="nav-link btn border-light" href="create_auction.php">+ Create auction</a>
       </li>');

--- a/listing.php
+++ b/listing.php
@@ -63,7 +63,7 @@ if ($auctionQuery && $auction = mysqli_fetch_assoc($auctionQuery)) {
     
     if (isset($imageID)) {
       $imageDataQuery = "SELECT imageFile FROM Images WHERE imageID='$imageID'";
-      $imageDataResult = mysqli_query($connection, $imageDataQuery) or die("Error making select userData query".mysql_error());
+      $imageDataResult = mysqli_query($connection, $imageDataQuery) or die("Error making select userData query".mysqli_error($connection));
 
       if ($imageDataResult && $imageDataRow = mysqli_fetch_assoc($imageDataResult)) {
         $imageData = base64_encode($imageDataRow['imageFile']);

--- a/listing.php
+++ b/listing.php
@@ -198,7 +198,14 @@ else {
 	    <input type="number" name="bid", class="form-control" id="bid" <?php echo($disabled);?> >
     </div>
     <button type="submit" class="btn btn-primary form-control" <?php echo($disabled);?>>Place bid</button>
-  </form>
+  </form><br>
+  <?php 
+  $suggestedPrice = suggestedPriceIncrease($item_id,$connection); 
+  $suggestedPrice = $suggestedPrice * ((float)$current_price) / 100;
+  $suggestedPrice = $suggestedPrice + ((float)$current_price);
+  $suggestedPrice = number_format($suggestedPrice, 2);
+  ?>
+  <p class="form-control">Suggested bid: £<?php echo($suggestedPrice); ?></p>
 <?php endif ?>
 
   

--- a/utilities.php
+++ b/utilities.php
@@ -129,5 +129,26 @@ function giveAuctionDetails ($auctionID,$databaseConnection) {
   return $auctionDetails;
 }
 
+function giveAuctionViews($auctionID,$databaseConnection) {
+  $auctionViewsQuery = "SELECT COUNT(userID) AS views
+                        FROM UserViews
+                        WHERE auctionID = $auctionID;";
+  $auctionViewsResult = mysqli_query($databaseConnection,$auctionViewsQuery);
+  $auctionViewRow = mysqli_fetch_assoc($auctionViewsResult);
+  return $auctionViewRow['views'];
+}
+
+
+function giveAuctionBids($auctionID,$databaseConnection) {
+  $auctionBidsQuery = "SELECT COUNT(bidID) AS bids
+                        FROM Bids
+                        WHERE auctionID = $auctionID;";
+  $auctionBidsResult = mysqli_query($databaseConnection,$auctionBidsQuery);
+  $auctionBidsRow = mysqli_fetch_assoc($auctionBidsResult);
+
+  return $auctionBidsRow['bids'];
+
+}
+
 
 ?>

--- a/utilities.php
+++ b/utilities.php
@@ -107,7 +107,6 @@ function print_bidding_li($item_id, $title, $desc, $price, $num_bids, $end_time,
         </li>
     ');
   }
-}
 
 
 // function returns important details regarding an auction from the auctionID 

--- a/utilities.php
+++ b/utilities.php
@@ -99,4 +99,35 @@ function print_bidding_li($item_id, $title, $desc, $price, $num_bids, $end_time,
     ');
 }
 
+
+// function returns important details regarding an auction from the auctionID 
+function giveAuctionDetails ($auctionID,$databaseConnection) {
+  $detailsQuery = "SELECT auctionTitle, sellerID, categoryID, auctionDescription, imageID, 
+                  startingPrice, reservePrice, currentPrice, startTime, endTime
+                  FROM Auctions
+                  WHERE auctionID = $auctionID";
+  $detailsResult = mysqli_query($databaseConnection,$detailsQuery);
+  $detailsRow = mysqli_fetch_assoc($detailsResult);
+  if (isset($detailsRow)) {
+      $auctionDetails = [
+          'auctionTitle' => $detailsRow['auctionTitle'],
+          'sellerID' => $detailsRow['sellerID'],
+          'categoryID' => $detailsRow['categoryID'],
+          'auctionDescription' => $detailsRow['auctionDescription'],
+          'imageID' => $detailsRow['imageID'],
+          'startingPrice' => $detailsRow['startingPrice'],
+          'reservePrice' => $detailsRow['reservePrice'],
+          'currentPrice' => $detailsRow['currentPrice'],
+          'startTime' => $detailsRow['startTime'],
+          'endTime' => $detailsRow['endTime']
+      ];
+  }
+  else {
+      $auctionDetails = NULL;
+  }
+  
+  return $auctionDetails;
+}
+
+
 ?>

--- a/utilities.php
+++ b/utilities.php
@@ -108,59 +108,6 @@ function print_bidding_li($item_id, $title, $desc, $price, $num_bids, $end_time,
     ');
   }
 
-
-// function returns important details regarding an auction from the auctionID 
-function giveAuctionDetails ($auctionID,$databaseConnection) {
-  $detailsQuery = "SELECT auctionTitle, sellerID, categoryID, auctionDescription, imageID, 
-                  startingPrice, reservePrice, currentPrice, startTime, endTime
-                  FROM Auctions
-                  WHERE auctionID = $auctionID";
-  $detailsResult = mysqli_query($databaseConnection,$detailsQuery);
-  $detailsRow = mysqli_fetch_assoc($detailsResult);
-  if (isset($detailsRow)) {
-      $auctionDetails = [
-          'auctionTitle' => $detailsRow['auctionTitle'],
-          'sellerID' => $detailsRow['sellerID'],
-          'categoryID' => $detailsRow['categoryID'],
-          'auctionDescription' => $detailsRow['auctionDescription'],
-          'imageID' => $detailsRow['imageID'],
-          'startingPrice' => $detailsRow['startingPrice'],
-          'reservePrice' => $detailsRow['reservePrice'],
-          'currentPrice' => $detailsRow['currentPrice'],
-          'startTime' => $detailsRow['startTime'],
-          'endTime' => $detailsRow['endTime']
-      ];
-  }
-  else {
-      $auctionDetails = NULL;
-  }
-  
-  return $auctionDetails;
-}
-
-function giveAuctionViews($auctionID,$databaseConnection) {
-  $auctionViewsQuery = "SELECT COUNT(userID) AS views
-                        FROM UserViews
-                        WHERE auctionID = $auctionID;";
-  $auctionViewsResult = mysqli_query($databaseConnection,$auctionViewsQuery);
-  $auctionViewRow = mysqli_fetch_assoc($auctionViewsResult);
-  return $auctionViewRow['views'];
-}
-
-
-function giveAuctionBids($auctionID,$databaseConnection) {
-  $auctionBidsQuery = "SELECT COUNT(bidID) AS bids
-                        FROM Bids
-                        WHERE auctionID = $auctionID;";
-  $auctionBidsResult = mysqli_query($databaseConnection,$auctionBidsQuery);
-  $auctionBidsRow = mysqli_fetch_assoc($auctionBidsResult);
-
-  return $auctionBidsRow['bids'];
-
-}
-
-
-
 // print_listing_li:
 // This function prints an HTML <li> element containing an auction listing
 function print_listing_li2($item_id, $title, $desc, $price, $num_bids, $end_time, $userViews, $date_added)
@@ -212,4 +159,56 @@ function print_listing_li2($item_id, $title, $desc, $price, $num_bids, $end_time
           </div>
       </li>
   ');
+}
+
+
+
+// function returns important details regarding an auction from the auctionID 
+function giveAuctionDetails ($auctionID,$databaseConnection) {
+  $detailsQuery = "SELECT auctionTitle, sellerID, categoryID, auctionDescription, imageID, 
+                  startingPrice, reservePrice, currentPrice, startTime, endTime
+                  FROM Auctions
+                  WHERE auctionID = $auctionID";
+  $detailsResult = mysqli_query($databaseConnection,$detailsQuery);
+  $detailsRow = mysqli_fetch_assoc($detailsResult);
+  if (isset($detailsRow)) {
+      $auctionDetails = [
+          'auctionTitle' => $detailsRow['auctionTitle'],
+          'sellerID' => $detailsRow['sellerID'],
+          'categoryID' => $detailsRow['categoryID'],
+          'auctionDescription' => $detailsRow['auctionDescription'],
+          'imageID' => $detailsRow['imageID'],
+          'startingPrice' => $detailsRow['startingPrice'],
+          'reservePrice' => $detailsRow['reservePrice'],
+          'currentPrice' => $detailsRow['currentPrice'],
+          'startTime' => $detailsRow['startTime'],
+          'endTime' => $detailsRow['endTime']
+      ];
+  }
+  else {
+      $auctionDetails = NULL;
+  }
+  
+  return $auctionDetails;
+}
+
+function giveAuctionViews($auctionID,$databaseConnection) {
+  $auctionViewsQuery = "SELECT COUNT(userID) AS views
+                        FROM UserViews
+                        WHERE auctionID = $auctionID;";
+  $auctionViewsResult = mysqli_query($databaseConnection,$auctionViewsQuery);
+  $auctionViewRow = mysqli_fetch_assoc($auctionViewsResult);
+  return $auctionViewRow['views'];
+}
+
+
+function giveAuctionBids($auctionID,$databaseConnection) {
+  $auctionBidsQuery = "SELECT COUNT(bidID) AS bids
+                        FROM Bids
+                        WHERE auctionID = $auctionID;";
+  $auctionBidsResult = mysqli_query($databaseConnection,$auctionBidsQuery);
+  $auctionBidsRow = mysqli_fetch_assoc($auctionBidsResult);
+
+  return $auctionBidsRow['bids'];
+
 }


### PR DESCRIPTION
Both changes should be combined into this pull request.

**Auction Analytics:**
When testing it may be useful to generate some dummy data for completed listings.


Bid Suggestions:
Work by finding the following information:
- Time to auction finish
- Number of views
- Number of bids
- Price increase of the latest bid 
These factors are used to generate a multiplier which acts on top of a base percentage increase suggestion (of currently at 5%).
Thus multiplier means the suggested price increase can be from 5%  TO 18.375%.